### PR TITLE
StepperStuff.evals is always an `Int`

### DIFF
--- a/src/dassl.jl
+++ b/src/dassl.jl
@@ -10,7 +10,7 @@ const MAXORDER = 6
 type StepperStuff{T<:Number}
     a     :: T
     g     :: Matrix{T}
-    evals :: Integer
+    evals :: Int
 end
 
 function dasslSolve{T<:Number}(F             :: Function,


### PR DESCRIPTION
`Integer` is a abstract type that will perform worse when used in a `type`. In this context it is probably not that important and it mostly looks funny for those who reads it and starts wondering when `evals` might be another integer type.
