### PR TITLE
common interface bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: julia
 notifications:
   email: false
 julia:
-  - 0.4
   - 0.5
   - nightly
 after_success:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
-julia 0.4
+julia 0.5
 FactCheck
+DiffEqBase

--- a/src/DASSL.jl
+++ b/src/DASSL.jl
@@ -2,6 +2,13 @@ module DASSL
 
 export dasslIterator, dasslSolve
 
+using DiffEqBase
+import DiffEqBase: solve
+
+export dassl
+
+include("common.jl")
+
 const MAXORDER = 6
 const MAXIT = 10
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,0 +1,51 @@
+abstract DASSLDAEAlgorithm <: AbstractODEAlgorithm
+immutable dassl <: DASSLDAEAlgorithm
+  maxorder
+  factorize_jacobian
+end
+
+dassl(;maxorder = 6,factorize_jacobian = true) = dassl(maxorder,factorize_jacobian)
+
+function solve{uType,duType,tType,isinplace,F}(
+    prob::AbstractDAEProblem{uType,duType,tType,isinplace,F},
+    alg::DASSLDAEAlgorithm,args...;timeseries_errors=true,
+    abstol=1e-5,reltol=1e-3,dt = 1e-4, dtmin = 0.0, dtmax = Inf,kwargs...)
+
+    tspan = [prob.tspan[1],prob.tspan[2]]
+
+    #sizeu = size(prob.u0)
+    #sizedu = size(prob.du0)
+
+    ### Fix inplace functions to the non-inplace version
+    if isinplace
+      f = (t,u,du) -> (out = similar(u); prob.f(t,u,du,out); out)
+    else
+      f = prob.f
+    end
+
+    ### Finishing Routine
+
+    ts,timeseries = dasslSolve(f,prob.u0,tspan,
+                                abstol=abstol,
+                                reltol=reltol,
+                                maxstep=dtmax,
+                                minstep=dtmin,
+                                initstep=dt,
+                                maxorder=alg.maxorder,
+                                factorize_jacobian=alg.factorize_jacobian)
+    #=
+    timeseries = Vector{uType}(0)
+    if typeof(prob.u0)<:Number
+        for i=1:length(ures)
+            push!(timeseries,ures[i][1])
+        end
+    else
+        for i=1:length(ures)
+            push!(timeseries,reshape(ures[i],sizeu))
+        end
+    end
+    =#
+
+    build_solution(prob,alg,ts,timeseries,
+                      timeseries_errors = timeseries_errors)
+end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+DiffEqProblemLibrary

--- a/test/common.jl
+++ b/test/common.jl
@@ -1,0 +1,7 @@
+using DiffEqProblemLibrary, DiffEqBase, DASSL
+
+prob = prob_dae_resrob
+
+sol = solve(prob,dassl())
+
+sol = solve(prob,dassl(),abstol = 1e-1, reltol = 1e-2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,3 +65,7 @@ facts("Testing minimal error tolerances") do
     end
     @fact tol --> roughly(1e-15)
 end
+
+facts("Testing common interface") do
+  include("common.jl")
+end


### PR DESCRIPTION
This adds common interface bindings so that for a `DAEProblem`, DASSL.jl can be called via

```julia
sol = solve(prob,dassl())
```

when @mauro3 's work on promotion is done, this will make it also a native BDF method for solving ODEs.

A lot of the DASSL arguments are able to be used, but not all. A further PR may add to this, including support for passing the Jacobian through the common interface way.

Note that since DASSL.jl needs a non-inplace version, this uses a closure to automatically change an inplace function a non-inplace function. To choose the size of the output, I made it match `du`. This is something that may be subject to change as we may need an "output prototype" in some cases (this would be needed to be added to the problem type).

All in all, it works and it's a good start.