### PR TITLE
Bump SciMLBase compat to v3 and bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DASSL"
 uuid = "e993076c-0cfd-5d6b-a1ac-36489fdf7917"
-version = "2.10.0"
+version = "2.11.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -22,7 +22,7 @@ JLArrays = "0.3"
 NonlinearSolve = "4"
 PrecompileTools = "1"
 Reexport = "0.2, 1.0"
-SciMLBase = "2"
+SciMLBase = "2, 3"
 SymbolicIndexingInterface = "0.3"
 julia = "1.10"
 


### PR DESCRIPTION
## Summary
- Update SciMLBase compat bounds to include v3
- Bump package version 2.10.0 → 2.11.0 (minor)
- No code changes needed - package doesn't use deprecated SciMLBase v2 patterns

Supersedes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)