### PR TITLE
Support SciMLBase v3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DASSL"
 uuid = "e993076c-0cfd-5d6b-a1ac-36489fdf7917"
-version = "2.10.0"
+version = "2.10.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -22,7 +22,7 @@ JLArrays = "0.3"
 NonlinearSolve = "4"
 PrecompileTools = "1"
 Reexport = "0.2, 1.0"
-SciMLBase = "2"
+SciMLBase = "2, 3.1"
 SymbolicIndexingInterface = "0.3"
 julia = "1.10"
 


### PR DESCRIPTION
## Summary

Courtesy PR for the SciMLBase v3 release, superseding the stalled dependabot PR #81.

- Extend `SciMLBase` compat to `"2, 3.1"` (keep v2 support via the lower bound).
- Bump `DASSL` version to 2.10.1.

No code changes required — a grep of `src/` found no references to the SciMLBase v3 breaking surface (`u_modified!`, removed `DEProblem` type alias, 3-arg ensemble `prob_func`, `.destats` / `.minimizer` / `.lb` getproperty aliases, or old iterators `tuples` / `intervals` / `TimeChoiceIterator`). The only `sol[...]` uses in `test/` are 2-arg symbolic indexing (`sol[x, 1]`, `sol[y, i]`), which is RAT-managed and unaffected by v3's scalar-int change.

## Known limitation

Local tests cannot be run: `Pkg.resolve()` fails on any env containing SciMLBase 3.1 because `OrdinaryDiffEq` in the registry still pins `RecursiveArrayTools ≤ 3.54` while SciMLBase 3.1 requires RAT v4. Expect CI here to fail at the `Pkg.add` step with an unsatisfiable resolution error until upstream OrdinaryDiffEq releases a RAT-v4-compatible version; re-running afterward should go green without further edits.

## Context

Part of the SciMLBase v3 ecosystem sweep — see SciML/DiffEqCallbacks.jl#300 and SciML/DiffEqParamEstim.jl#290 for the reference patterns.

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)