### PR TITLE
Bump for SciMLBase v3 / DiffEqBase v7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DASSL"
 uuid = "e993076c-0cfd-5d6b-a1ac-36489fdf7917"
-version = "2.11.0"
+version = "2.12.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -17,7 +17,7 @@ SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 AllocCheck = "0.2"
 ArrayInterface = "7"
 BenchmarkTools = "1"
-DiffEqBase = "6.217"
+DiffEqBase = "6.217, 7"
 ExplicitImports = "1"
 JLArrays = "0.3"
 NonlinearSolve = "4"

--- a/src/DASSL.jl
+++ b/src/DASSL.jl
@@ -127,7 +127,7 @@ function dasslStep(
         if status < 0
             # Early failure: Newton iteration failed to converge, reduce
             # the step size and try again
-            @SciMLMessage("Newton iteration failed to converge (h=$h at t=$(tout[end]))", verbose, :step_rejection)
+            @SciMLMessage("Newton iteration failed to converge (h=$h at t=$(tout[end]))", verbose, :step_rejected)
 
             # increase the failure counter
             num_fail += 1
@@ -140,7 +140,7 @@ function dasslStep(
         elseif err > 1
             # local error is too large.  Step is rejected, and we try
             # again with new step size and order.
-            @SciMLMessage("Local error too large, rejecting step (err=$err, h=$h at t=$(tout[end]))", verbose, :step_rejection)
+            @SciMLMessage("Local error too large, rejecting step (err=$err, h=$h at t=$(tout[end]))", verbose, :step_rejected)
 
             # increase the failure counter
             num_fail += 1

--- a/src/inplace.jl
+++ b/src/inplace.jl
@@ -608,7 +608,7 @@ function dasslSolve!(
 
         if status < 0
             # Newton failed, reduce step
-            @SciMLMessage("Newton iteration failed to converge (h=$h at t=$(tout[end]))", verbose, :step_rejection)
+            @SciMLMessage("Newton iteration failed to converge (h=$h at t=$(tout[end]))", verbose, :step_rejected)
             num_fail += 1
             num_rejected += 1
             h *= 1 / 4
@@ -616,7 +616,7 @@ function dasslSolve!(
 
         elseif err > 1
             # Error too large, reduce step
-            @SciMLMessage("Local error too large, rejecting step (err=$err, h=$h at t=$(tout[end]))", verbose, :step_rejection)
+            @SciMLMessage("Local error too large, rejecting step (err=$err, h=$h at t=$(tout[end]))", verbose, :step_rejected)
             num_fail += 1
             num_rejected += 1
 


### PR DESCRIPTION
## Summary

Bumps DASSL.jl compat to support **DiffEqBase v7** (alongside SciMLBase v3, which is already supported from #83). Also fixes a pre-existing runtime typo in the SciMLLogging integration that was causing every `solve()` to error at the first step rejection.

## Changes

- `Project.toml`: `DiffEqBase` compat `"6.217"` → `"6.217, 7"`; version `2.11.0` → `2.12.0` (minor bump for compat expansion).
- `src/DASSL.jl` and `src/inplace.jl`: `@SciMLMessage(..., :step_rejection)` → `:step_rejected`. The `DEVerbosity` struct has a `step_rejected` field; `step_rejection` errored at runtime (`FieldError`), so the tests were broken on master independent of this bump.

No code-level migrations were needed for OrdinaryDiffEq v7 / SciMLBase v3 / RecursiveArrayTools v4 — greps across `src/` and `test/` for the full breaking-API list from the OrdinaryDiffEq v7 NEWS (`u_modified!`, `.destats`, `DEAlgorithm`, `tuples`/`intervals`, `prob_func`/`output_func` old sig, Bool `autodiff`/`verbose`/`alias`/`lazy`, PID controller kwargs, `EEst`, `construct*` tableaus, `RECOMPILE_BY_DEFAULT`, RAT v4 `sol[i]` indexing, etc.) came up empty. DASSL doesn't depend on OrdinaryDiffEq directly.

Supersedes #87 (dependabot, compat-only).

## Test plan

- [x] `julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.test()'` — all testsets pass locally against the resolved environment (DiffEqBase v7.0.0, SciMLBase v3.4.3):
  - `maxorder` (36/36)
  - `common interface` (was erroring before the typo fix)
  - `ModelingToolkit DAE Initialization` (46/46)
  - `Interface Compatibility` (12/12)
  - `Convergence tests` (20/20)
  - `In-Place Operations` (36/36)
  - `QA` (20/20)
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)