### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -13,20 +13,8 @@ on:
 jobs:
   test:
     if: false  # Disabled: waiting on dependency updates. See issue for details.
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,5 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## What this does

Moves all CI checks onto the centralized SciML reusable workflows (pinned `@v1`), each caller passing `secrets: "inherit"`. End-state matches Sundials.jl.

### Converted (inline -> central caller)
- **FormatCheck.yml**: `fredrikekre/runic-action` inline -> `SciML/.github/.github/workflows/runic.yml@v1`
- **SpellCheck.yml**: `crate-ci/typos` inline -> `SciML/.github/.github/workflows/spellcheck.yml@v1`
- **Downgrade.yml**: inline downgrade job -> `SciML/.github/.github/workflows/downgrade.yml@v1` (preserved `julia-version: 1.10`, `skip: Pkg,TOML`, and the existing `if: false` gate)

### Already central (left as-is)
- **Tests.yml**: already calls `tests.yml@v1` with the `version` x `os` matrix and `secrets: "inherit"`.

### Not applicable
- No `docs/` directory -> no Documentation caller.
- No downstream/IntegrationTest or AirspeedVelocity workflows -> none added.
- No `CompatHelper.yml` present.

### Cleanup
- Removed the `crate-ci/typos` ignore entry from `dependabot.yml` (spellcheck is now centralized). Kept the `github-actions` (`/`, weekly) and `julia` (`/`, `/test`, daily, group `all-julia-packages: ["*"]`) blocks.
- TagBot.yml left unchanged.

### Checks
- typos: ran `typos .` -> clean (exit 0), no fixes needed.
- Runic: ran `Runic.main(["--inplace","."])` -> no source changes (repo was already Runic-formatted via the prior inline check).

> [!WARNING]
> Check names change (jobs now run as reusable-workflow callers). Branch-protection required-status-check names will need updating accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)