### PR TITLE
Run Runic formatter on the repository

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,9 @@
 using DASSL, Test
 using LinearAlgebra: diagm, I
 
-const GROUP = let g = get(ENV, "GROUP", "all"); isempty(g) ? "all" : g end
+const GROUP = let g = get(ENV, "GROUP", "all")
+    isempty(g) ? "all" : g
+end
 
 if GROUP == "all" || GROUP == "core"
     @testset "Testing maxorder" begin


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.** Draft.

Runs the Runic.jl v1 formatter over the repository so the `format-check` CI (the centralized `SciML/.github/.github/workflows/runic.yml@v1` reusable workflow, `fredrikekre/runic-action@v1`) passes.

## Change

The **only** change is in `test/runtests.jl`: a `let ... end` one-liner (introduced in #93) expanded to multi-line form. This is what currently makes `format-check` red on master.
```diff
-const GROUP = let g = get(ENV, "GROUP", "all"); isempty(g) ? "all" : g end
+const GROUP = let g = get(ENV, "GROUP", "all")
+    isempty(g) ? "all" : g
+end
```
Formatting-only and semantically identical. The other 13 tracked `.jl` files were already Runic-clean.

## Verification (clean-room, independent fresh clones)

- **CI parity:** fresh depot + fresh `Runic v1.7.0` (the version `runic-action@v1` resolves), `runic --check` over `git ls-files '*.jl'` (14 files) → **exit 0, no diff**. CI `format-check` will pass.
- **Semantic identity:** only `test/runtests.jl` differs from master; the `const GROUP` value is identical for GROUP unset/`""`/`"all"`/`"core"`/`"QA"`; and `Meta.parseall` with `LineNumberNode`s stripped compares **AST-equal** between the two versions.
- **Tests:** full suite on the formatted tree (Julia 1.10) → **184 pass / 0 fail**, `Pkg.test` exit 0 (ModelingToolkit DAE Initialization 46/46, Testing common interface 4/4, QA 20/20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)