### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -14,19 +14,5 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1"
-          - "lts"
-          - "pre"
-        os:
-          - "ubuntu-latest"
-          - "windows-latest"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "${{ matrix.version }}"
-      os: "${{ matrix.os }}"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/Project.toml
+++ b/Project.toml
@@ -14,10 +14,12 @@ SciMLLogging = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 
 [compat]
+AllocCheck = "0.2"
 ArrayInterface = "7.25.0"
 BenchmarkTools = "1"
 DAEProblemLibrary = "0.1"
 DiffEqBase = "7.5.5"
+ExplicitImports = "1.4.2"
 JLArrays = "0.3"
 ModelingToolkit = "10, 11"
 NonlinearSolve = "4.19.1"
@@ -30,8 +32,10 @@ Test = "1"
 julia = "1.10"
 
 [extras]
+AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 DAEProblemLibrary = "dfb8ca35-80a1-48ba-a605-84916a45b4f8"
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
@@ -39,4 +43,4 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["BenchmarkTools", "DAEProblemLibrary", "JLArrays", "ModelingToolkit", "NonlinearSolve", "Pkg", "Test"]
+test = ["AllocCheck", "BenchmarkTools", "DAEProblemLibrary", "ExplicitImports", "JLArrays", "ModelingToolkit", "NonlinearSolve", "Pkg", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -14,29 +14,28 @@ SciMLLogging = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 
 [compat]
-AllocCheck = "0.2"
 ArrayInterface = "7.25.0"
 BenchmarkTools = "1"
+DAEProblemLibrary = "0.1"
 DiffEqBase = "7.5.5"
-ExplicitImports = "1.4.2"
 JLArrays = "0.3"
+ModelingToolkit = "10, 11"
 NonlinearSolve = "4.19.1"
 PrecompileTools = "1.2.1"
 Reexport = "1.2.2"
 SciMLBase = "3.18.0"
 SciMLLogging = "1.10.1, 2"
 SymbolicIndexingInterface = "0.3.48"
+Test = "1"
 julia = "1.10"
 
 [extras]
-AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 DAEProblemLibrary = "dfb8ca35-80a1-48ba-a605-84916a45b4f8"
-ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AllocCheck", "BenchmarkTools", "DAEProblemLibrary", "ExplicitImports", "JLArrays", "ModelingToolkit", "NonlinearSolve", "Test"]
+test = ["BenchmarkTools", "DAEProblemLibrary", "JLArrays", "ModelingToolkit", "NonlinearSolve", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -35,7 +35,8 @@ DAEProblemLibrary = "dfb8ca35-80a1-48ba-a605-84916a45b4f8"
 JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["BenchmarkTools", "DAEProblemLibrary", "JLArrays", "ModelingToolkit", "NonlinearSolve", "Test"]
+test = ["BenchmarkTools", "DAEProblemLibrary", "JLArrays", "ModelingToolkit", "NonlinearSolve", "Pkg", "Test"]

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,0 +1,14 @@
+[deps]
+AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
+DASSL = "e993076c-0cfd-5d6b-a1ac-36489fdf7917"
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+DASSL = {path = "../.."}
+
+[compat]
+AllocCheck = "0.2"
+ExplicitImports = "1.4.2"
+julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,0 +1,21 @@
+using DASSL
+using Test
+
+@testset "QA" begin
+    @testset "Explicit Imports" begin
+        include(joinpath(@__DIR__, "..", "explicit_imports.jl"))
+    end
+
+    @testset "Type Stability" begin
+        alg = dassl()
+        @test typeof(alg.maxorder) === Int
+        @test typeof(alg.factorize_jacobian) === Bool
+
+        y0 = [1.0, 2.0]
+        cache = DASSL.alg_cache(alg, y0, nothing, 0.0, Val(true))
+        @test isconcretetype(typeof(cache.jac_factorized))
+        @test !(cache.jac_factorized isa Any && typeof(cache.jac_factorized) === Any)
+    end
+
+    include(joinpath(@__DIR__, "..", "alloc_tests.jl"))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,13 +1,12 @@
 using Test
+using DASSL
+using LinearAlgebra: diagm, I
 
 const GROUP = let g = get(ENV, "GROUP", "All")
     isempty(g) ? "All" : g
 end
 
 if GROUP == "All" || GROUP == "Core"
-    using DASSL
-    using LinearAlgebra: diagm, I
-
     @testset "Testing maxorder" begin
         F(t, y, dy) = (dy + y .^ 2)
         Fy(t, y, dy) = diagm(0 => 2y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,13 @@
-using DASSL, Test
-using LinearAlgebra: diagm, I
+using Test
 
-const GROUP = let g = get(ENV, "GROUP", "all")
-    isempty(g) ? "all" : g
+const GROUP = let g = get(ENV, "GROUP", "All")
+    isempty(g) ? "All" : g
 end
 
-if GROUP == "all" || GROUP == "core"
+if GROUP == "All" || GROUP == "Core"
+    using DASSL
+    using LinearAlgebra: diagm, I
+
     @testset "Testing maxorder" begin
         F(t, y, dy) = (dy + y .^ 2)
         Fy(t, y, dy) = diagm(0 => 2y)
@@ -75,23 +77,10 @@ if GROUP == "all" || GROUP == "core"
     end
 end
 
-if GROUP == "all" || GROUP == "QA"
-    @testset "QA" begin
-        @testset "Explicit Imports" begin
-            include("explicit_imports.jl")
-        end
-
-        @testset "Type Stability" begin
-            alg = dassl()
-            @test typeof(alg.maxorder) === Int
-            @test typeof(alg.factorize_jacobian) === Bool
-
-            y0 = [1.0, 2.0]
-            cache = DASSL.alg_cache(alg, y0, nothing, 0.0, Val(true))
-            @test isconcretetype(typeof(cache.jac_factorized))
-            @test !(cache.jac_factorized isa Any && typeof(cache.jac_factorized) === Any)
-        end
-
-        include("alloc_tests.jl")
-    end
+if GROUP == "QA"
+    import Pkg
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    Pkg.develop(path = joinpath(@__DIR__, ".."))
+    Pkg.instantiate()
+    include(joinpath(@__DIR__, "qa", "qa.jl"))
 end

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,6 @@
+[Core]
+versions = ["lts", "1", "pre"]
+os = ["ubuntu-latest", "windows-latest"]
+
+[QA]
+versions = ["lts", "1"]


### PR DESCRIPTION
## Summary

Converts the root **Tests.yml** from a hand-maintained `version × os` matrix (calling `tests.yml@v1`) into a thin caller of the canonical **`grouped-tests.yml@v1`**, with the test matrix declared once in **`test/test_groups.toml`**.

### Changes
- **`.github/workflows/Tests.yml`** — the matrix test job is replaced by the canonical thin caller:
  ```yaml
  jobs:
    tests:
      uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
      secrets: "inherit"
  ```
  `name:`, `on:`, and `concurrency:` are preserved verbatim. No `with:` block is needed — every input matches the canonical default and the prior behavior (group env `GROUP`, `check-bounds: yes`, coverage on, `coverage-directories: src,ext`, no apt packages). Other workflows (Downgrade/FormatCheck/RunicSuggestions/SpellCheck/TagBot/DependabotAutoMerge) are untouched.
- **`test/test_groups.toml`** (new) — the matrix:
  ```toml
  [Core]
  versions = ["lts", "1", "pre"]
  os = ["ubuntu-latest", "windows-latest"]

  [QA]
  versions = ["lts", "1"]
  ```
- **QA isolation (Category B)** — this repo previously ran its QA-style checks (ExplicitImports, type-stability, AllocCheck allocation tests) inline under `GROUP=="all"/"QA"`, with `AllocCheck`/`ExplicitImports` in the root test target. They are now refactored into a gated `GROUP=="QA"` path with an isolated environment:
  - `test/qa/Project.toml` — `[deps]` = AllocCheck + ExplicitImports + Test + LinearAlgebra + DASSL via `[sources] path = "../.."`; `[compat] julia = "1.10"`.
  - `test/qa/qa.jl` — the moved QA testset (ExplicitImports, type-stability, alloc tests).
  - `test/runtests.jl` — `Core`/`All` run the functional suite; `QA` does `Pkg.activate(test/qa)` + `Pkg.develop(path=repo root)` + `Pkg.instantiate()` then includes `qa.jl`. Group dispatch updated to the canonical capitalized names (`All`/`Core`/`QA`).
- **`Project.toml`** — benign metadata fixes: dropped `AllocCheck`/`ExplicitImports` from the root `[extras]`/`[targets]` (now QA-isolated); added missing `[compat]` for the remaining extras (`DAEProblemLibrary = "0.1"`, `ModelingToolkit = "10, 11"`, `Test = "1"`). `julia` compat already at the 1.10 LTS floor.

### Matrix match
Verified statically with `scripts/compute_affected_sublibraries.jl --root-matrix` (no tests/Aqua run locally — structural conversion only). Emitted set:
- **Core**: `{lts, 1, pre} × {ubuntu-latest, windows-latest}` = 6 cells → exactly reproduces the OLD functional `version × os` coverage.
- **QA**: `{lts, 1} × {ubuntu-latest}` = 2 cells → the QA checks (previously riding along on all 6 cells via the default `GROUP=all`) now run isolated on the canonical QA subset.

TOML + YAML parse and `runtests.jl`/`qa.jl` Julia-parse were verified statically.

### Note
The QA group is newly wired as a separate CI job; its Aqua/JET (here: ExplicitImports + type-stability + AllocCheck) run in CI. Any failures will be triaged in a follow-up — no checks were skipped or silenced.

**Ignore until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)