### PR TITLE
Canonicalize test units to @safetestset

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,6 +25,7 @@ ModelingToolkit = "10, 11"
 NonlinearSolve = "4.19.1"
 PrecompileTools = "1.2.1"
 Reexport = "1.2.2"
+SafeTestsets = "0.1, 1"
 SciMLBase = "3.18.0"
 SciMLLogging = "1.10.1, 2"
 SymbolicIndexingInterface = "0.3.48"
@@ -40,7 +41,8 @@ JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AllocCheck", "BenchmarkTools", "DAEProblemLibrary", "ExplicitImports", "JLArrays", "ModelingToolkit", "NonlinearSolve", "Pkg", "Test"]
+test = ["AllocCheck", "BenchmarkTools", "DAEProblemLibrary", "ExplicitImports", "JLArrays", "ModelingToolkit", "NonlinearSolve", "Pkg", "SafeTestsets", "Test"]

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -3,6 +3,7 @@ AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 DASSL = "e993076c-0cfd-5d6b-a1ac-36489fdf7917"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
@@ -11,4 +12,5 @@ DASSL = {path = "../.."}
 [compat]
 AllocCheck = "0.2"
 ExplicitImports = "1.4.2"
+SafeTestsets = "0.1, 1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,21 +1,23 @@
-using DASSL
-using Test
+using SafeTestsets
 
-@testset "QA" begin
-    @testset "Explicit Imports" begin
-        include(joinpath(@__DIR__, "..", "explicit_imports.jl"))
-    end
+@safetestset "Explicit Imports" begin
+    include(joinpath(@__DIR__, "..", "explicit_imports.jl"))
+end
 
-    @testset "Type Stability" begin
-        alg = dassl()
-        @test typeof(alg.maxorder) === Int
-        @test typeof(alg.factorize_jacobian) === Bool
+@safetestset "Type Stability" begin
+    using DASSL
+    using Test
 
-        y0 = [1.0, 2.0]
-        cache = DASSL.alg_cache(alg, y0, nothing, 0.0, Val(true))
-        @test isconcretetype(typeof(cache.jac_factorized))
-        @test !(cache.jac_factorized isa Any && typeof(cache.jac_factorized) === Any)
-    end
+    alg = dassl()
+    @test typeof(alg.maxorder) === Int
+    @test typeof(alg.factorize_jacobian) === Bool
 
+    y0 = [1.0, 2.0]
+    cache = DASSL.alg_cache(alg, y0, nothing, 0.0, Val(true))
+    @test isconcretetype(typeof(cache.jac_factorized))
+    @test !(cache.jac_factorized isa Any && typeof(cache.jac_factorized) === Any)
+end
+
+@safetestset "Allocation Tests" begin
     include(joinpath(@__DIR__, "..", "alloc_tests.jl"))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,13 +1,16 @@
 using Test
-using DASSL
-using LinearAlgebra: diagm, I
+using SafeTestsets
 
 const GROUP = let g = get(ENV, "GROUP", "All")
     isempty(g) ? "All" : g
 end
 
 if GROUP == "All" || GROUP == "Core"
-    @testset "Testing maxorder" begin
+    @safetestset "Testing maxorder" begin
+        using DASSL
+        using LinearAlgebra: diagm, I
+        using Test
+
         F(t, y, dy) = (dy + y .^ 2)
         Fy(t, y, dy) = diagm(0 => 2y)
         Fdy(t, y, dy) = Matrix{Float64}(I, length(y), length(y))
@@ -52,26 +55,28 @@ if GROUP == "All" || GROUP == "Core"
         end
     end
 
-    @testset "Testing common interface" begin
+    @safetestset "Testing common interface" begin
         include("common.jl")
     end
 
-    @testset "DAE Initialization" begin
+    @safetestset "DAE Initialization" begin
         include("initialization_tests.jl")
     end
 
-    @testset "ModelingToolkit DAE Initialization" begin
+    @safetestset "ModelingToolkit DAE Initialization" begin
         include("mtk_initialization_tests.jl")
     end
 
-    @testset "Interface Compatibility" begin
+    @safetestset "Interface Compatibility" begin
         include("interface.jl")
     end
 
-    include("convergence.jl")
+    @safetestset "Convergence tests" begin
+        include("convergence.jl")
+    end
 
     # In-place tests
-    @testset "In-Place Operations" begin
+    @safetestset "In-Place Operations" begin
         include("inplace_tests.jl")
     end
 end


### PR DESCRIPTION
## Summary

Wraps each independent test unit in `@safetestset` so it runs in its own module, giving isolation between units and world-age safety, matching the canonical OrdinaryDiffEq test structure.

### Changes
- **`test/runtests.jl`** (`Core`/`All` block): the seven units become `@safetestset`. The inline `"Testing maxorder"` unit carries its own imports (`DASSL`, `LinearAlgebra: diagm/I`, `Test`); the `include()` units (common interface, DAE Initialization, ModelingToolkit DAE Initialization, Interface Compatibility, Convergence tests, In-Place Operations) wrap their existing self-contained files. The previously bare `include("convergence.jl")` is wrapped as `@safetestset "Convergence tests"`.
- **`test/qa/qa.jl`**: the three units under the `"QA"` testset (Explicit Imports, Type Stability, Allocation Tests) become `@safetestset`; Type Stability carries its own `using DASSL`/`using Test`, the other two `include` their existing self-contained files.
- Added `SafeTestsets` to the test deps (root `[extras]`/`[targets]` and `test/qa/Project.toml`) with compat `"0.1, 1"`.

The `GROUP` dispatch, the set of tests that run, and all assertions are unchanged. Behavior-preserving: only unit wrapping + self-containment.

### Verification
Ran locally with Julia 1.11:
- `GROUP=Core`: all seven safetestsets pass — Testing maxorder 36/36, Testing common interface 4/4, DAE Initialization 10/10, ModelingToolkit DAE Initialization 46/46, Interface Compatibility 12/12, Convergence tests 20/20, In-Place Operations 36/36.
- `GROUP=QA`: Explicit Imports 2/2, Type Stability 4/4, Allocation Tests 14/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Ignore until reviewed by @ChrisRackauckas.