### PR TITLE
Bump version to 3.0.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DASSL"
 uuid = "e993076c-0cfd-5d6b-a1ac-36489fdf7917"
-version = "3.0.2"
+version = "3.0.3"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (3.0.2 -> 3.0.3) to release unreleased commits on `master` via JuliaRegistrator.