### PR TITLE
Release prep: bump DASSL to 3.0.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DASSL"
 uuid = "e993076c-0cfd-5d6b-a1ac-36489fdf7917"
-version = "3.0.3"
+version = "3.0.4"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
Patch release for the accumulated docstring/QA/test scaffolding changes since 3.0.3 (SciMLTesting compat bump and removal of a redundant QA [sources] self-path).