### PR TITLE
Add rendered public API docs QA

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+Manifest.toml
+build/

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,7 @@
+[deps]
+DASSL = "e993076c-0cfd-5d6b-a1ac-36489fdf7917"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "1"
+julia = "1.10"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,27 @@
+using Pkg
+
+Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+Pkg.instantiate()
+
+using DASSL
+using Documenter
+
+makedocs(;
+    modules = [DASSL],
+    authors = "Chris Rackauckas <accounts@chrisrackauckas.com>",
+    sitename = "DASSL.jl",
+    checkdocs = :exports,
+    format = Documenter.HTML(;
+        canonical = "https://docs.sciml.ai/DASSL/stable/",
+        edit_link = "master",
+        assets = String[],
+    ),
+    pages = [
+        "Public API" => "index.md",
+    ],
+)
+
+deploydocs(;
+    repo = "github.com/SciML/DASSL.jl.git",
+    push_preview = true,
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,16 @@
+# DASSL.jl
+
+```@meta
+CurrentModule = DASSL
+```
+
+## Public API
+
+```@docs
+dassl
+dasslSolve
+dasslSolve!
+dasslIterator
+DASSLCache
+alg_cache
+```

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,10 +1,13 @@
 using SciMLTesting, DASSL, Test
 
+diffeqbase_reexports = Tuple(names(DASSL.DiffEqBase))
+
 # Remaining names are still non-public in their *own* packages (SciMLBase/DiffEqBase
 # internals DASSL legitimately depends on); ignore them here and drop each as its
 # source package marks the name public.
 run_qa(
     DASSL; explicit_imports = true,
+    api_docs_kwargs = (; rendered = true, rendered_ignore = diffeqbase_reexports),
     ei_kwargs = (;
         all_explicit_imports_are_public = (;
             ignore = (


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- add a minimal Documenter manual that renders the package-owned exported DASSL API
- enable SciMLTesting rendered public-docs QA
- ignore DiffEqBase reexports for the rendered-docs check so DASSL does not duplicate upstream API pages

## Validation
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=docs docs/make.jl` passed; only local Documenter deployment warning
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=test/qa -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("test/qa/qa.jl")'` passed: `Quality Assurance | 17/17`, `Type Stability | 4/4`, `Allocation Tests | 14/14`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'` passed: `DASSL tests passed`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.activate(temp=true); Pkg.add(PackageSpec(name="Runic", version="1")); using Runic; exit(Runic.main(["--check", "."]))'` passed
- `git diff --check` passed
